### PR TITLE
Set up for CSDMS JupyterHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,4 @@ Follow these steps:
 
 1. [Create an account](https://csdms.rc.colorado.edu/hub/signup) on the CSDMS JupyterHub, providing a username and password--they can be whatever you like
 1. [Request authorization](https://github.com/csdms/help-desk/issues/new?assignees=mdpiper&labels=jupyterhub&template=new-csdms-jupyterhub-account.md&title=CSDMS+JupyterHub+account) for your new account through the CSDMS Help Desk--if you don't already have a GitHub account, you'll be asked to make one
-1. Once approved, [run Jupyter Notebooks](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fnhm-usgs%2Fbmi-prms-demo&urlpath=tree%2Fbmi-prms-demo%2Fnotebooks&branch=mdpiper/to-csdms-hub)
-
+1. Once approved, [run Jupyter Notebooks](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fnhm-usgs%2Fbmi-prms-demo&urlpath=tree%2Fbmi-prms-demo%2Fnotebooks&branch=master)

--- a/README.md
+++ b/README.md
@@ -39,4 +39,13 @@ The git repositories for each BMI can be found at https://github.com/nhm-usgs
 Each BMI depends on the PRMS6 model and library found at the prms repository currently using the 6.0.0_dev_bmi branch
 
 
+### Run on the CSDMS JupyterHub
+
+Instead of installing locally,
+the PRMS component Notebooks can be run on the CSDMS JupyterHub.
+Follow these steps:
+
+1. [Create an account](https://csdms.rc.colorado.edu/hub/signup) on the CSDMS JupyterHub, providing a username and password--they can be whatever you like
+1. [Request authorization](https://github.com/csdms/help-desk/issues/new?assignees=mdpiper&labels=jupyterhub&template=new-csdms-jupyterhub-account.md&title=CSDMS+JupyterHub+account) for your new account through the CSDMS Help Desk--if you don't already have a GitHub account, you'll be asked to make one
+1. Once approved, [run Jupyter Notebooks](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fnhm-usgs%2Fbmi-prms-demo&urlpath=tree%2Fbmi-prms-demo%2Fnotebooks&branch=mdpiper/to-csdms-hub)
 

--- a/prms/pipestem/output/.gitignore
+++ b/prms/pipestem/output/.gitignore
@@ -1,0 +1,5 @@
+# https://stackoverflow.com/a/932982/1563298
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This PR adds links to the README for running the PRMS Notebooks on the CSDMS JupyterHub. Note that the links point to the master branch of this repo.