### PR TITLE
Set minimum version for pymt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - geopandas
   - descartes
   - requests
-  - pymt
+  - pymt >=1.3
   - pymt_prms_surface
   - pymt_prms_soil
   - pymt_prms_groundwater


### PR DESCRIPTION
This PR makes one tiny change--setting a minimum version on *pymt*. The change has outsized effects, though, helping `conda` find the latest compatible versions of *pymt* and the PRMS components.